### PR TITLE
Update Postgres to 18.4 on kernel528/alpine:3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,9 +20,9 @@ steps:
       repo: kernel528/postgres
       tags:
         - '18'
-        - '18.1.0-260128'
+        - '18.4.0-260710'
         - '18-drone-build-${DRONE_BUILD_NUMBER}'
-        - '18.1.0-260128-drone-build-${DRONE_BUILD_NUMBER}'
+        - '18.4.0-260710-drone-build-${DRONE_BUILD_NUMBER}'
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@
 Use the latest tag from `VERSION.md` in examples; update these if the tag changes.
 - Build the image locally:
   ```sh
-  docker image build -t kernel528/postgres:18.1.0-260128 -f Dockerfile .
+  docker image build -t kernel528/postgres:18.4.0-260710 -f Dockerfile .
   ```
 - Run a container:
   ```sh
-  docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password -d kernel528/postgres:18.1.0-260128
+  docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password -d kernel528/postgres:18.4.0-260710
   ```
 - Manual smoke test (inside container):
   ```sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.23.2
+FROM kernel528/alpine:3.24.1
 
 # Based on: https://github.com/docker-library/postgres/blob/master/16/alpine3.21/Dockerfile
 
@@ -51,12 +51,12 @@ ENV LANG en_US.utf8
 RUN mkdir /docker-entrypoint-initdb.d
 
 ENV PG_MAJOR 18
-ENV PG_VERSION 18.1
-ENV PG_SHA256 ff86675c336c46e98ac991ebb306d1b67621ece1d06787beaade312c2c915d54
+ENV PG_VERSION 18.4
+ENV PG_SHA256 81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094
 
 ENV DOCKER_PG_LLVM_DEPS \
-		llvm19-dev \
-		clang19
+		llvm21-dev \
+		clang21
 
 RUN set -eux; \
 	\
@@ -104,6 +104,9 @@ RUN set -eux; \
 # https://salsa.debian.org/postgresql/postgresql-common/-/commit/89c384273f4c4092483598c292b1b1b188816cce
 # https://www.postgresql.org/docs/18/install-make.html#CONFIGURE-OPTION-WITH-LIBURING
 		liburing-dev \
+# https://salsa.debian.org/postgresql/postgresql-common/-/commit/a31ce5b893c11e0f17a016e38c1882fbe1820081
+# https://www.postgresql.org/docs/18/install-make.html#CONFIGURE-OPTION-WITH-LIBCURL
+		curl-dev \
 	; \
 	\
 	cd /usr/src/postgresql; \
@@ -115,9 +118,9 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	\
 # https://git.alpinelinux.org/aports/tree/community/postgresql15/APKBUILD?h=3.22-stable#n176 ("export LLVM_CONFIG")
-	export LLVM_CONFIG="/usr/lib/llvm19/bin/llvm-config"; \
+	export LLVM_CONFIG="/usr/lib/llvm21/bin/llvm-config"; \
 # https://git.alpinelinux.org/aports/tree/community/postgresql15/APKBUILD?h=3.22-stable#n180 ("older clang versions don't have a 'clang' exe anymore.")
-	export CLANG=clang-19; \
+	export CLANG=clang-21; \
 	\
 # configure options mostly copying Debian:
 # https://salsa.debian.org/postgresql/postgresql-common/-/blob/6e26b5107295170cc8731a3acbf13228ea15941e/server/postgresql.mk#L32
@@ -141,6 +144,7 @@ RUN set -eux; \
 		--with-icu \
 		--with-ldap \
 		--with-liburing \
+		--with-libcurl \
 		--with-libxml \
 		--with-libxslt \
 		--with-llvm \

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Based on: [Postgres Official Docker - Alpine](https://github.com/docker-library/
 
 ## Build
 ```
-docker image build -t kernel528/postgres:18.1.0-260128 -f Dockerfile .
+docker image build -t kernel528/postgres:18.4.0-260710 -f Dockerfile .
 ```
 
 ## Run
 ```
-docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password --hostname=postgres-local -d kernel528/postgres:18.1.0-260128
+docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password --hostname=postgres-local -d kernel528/postgres:18.4.0-260710
 ```
 
 ## Configuration
@@ -43,7 +43,7 @@ docker run -it -d \
   -e POSTGRES_PASSWORD=password \
   -v postgres-data:/var/lib/postgresql/data \
   -v "$(pwd)/sample-postgres-db.sql:/docker-entrypoint-initdb.d/01-sample.sql:ro" \
-  kernel528/postgres:18.1.0-260128
+  kernel528/postgres:18.4.0-260710
 ```
 
 ## Tagging

--- a/VERSION.md
+++ b/VERSION.md
@@ -28,3 +28,4 @@ Notes:
 - 16.11.0-251126: Updated to Postgres 16.11 and kernel528/alpine:3.22.2.
 - 16.11.0-260101: Updated base image to kernel528/alpine:3.23.2.
 - 18.1.0-260128: Updated to Postgres 18.1 and kernel528/alpine:3.23.2.
+- 18.4.0-260710: Updated to Postgres 18.4 and kernel528/alpine:3.24.1.


### PR DESCRIPTION
## Changes

- **Base image**: `kernel528/alpine:3.23.2` → `kernel528/alpine:3.24.1`
- **PostgreSQL**: `18.1` → `18.4` (latest minor release)
- **LLVM**: `llvm19-dev`/`clang19` → `llvm21-dev`/`clang21` (Alpine 3.24 compat)
- Added `curl-dev` build dep and `--with-libcurl` configure flag
- Updated `.drone.yml`, `README.md`, `VERSION.md`, `AGENTS.md` for new version

## Validation

- [x] Image built successfully (compiled from source with LLVM 21)
- [x] `postgres --version` → `postgres (PostgreSQL) 18.4`
- [x] `cat /etc/alpine-release` → `3.24.1`