### PR TITLE
Rebuild Postgres 18.4 on Alpine 3.24.1_1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,9 +20,9 @@ steps:
       repo: kernel528/postgres
       tags:
         - '18'
-        - '18.4.0-260710'
+        - '18.4.0-260718'
         - '18-drone-build-${DRONE_BUILD_NUMBER}'
-        - '18.4.0-260710-drone-build-${DRONE_BUILD_NUMBER}'
+        - '18.4.0-260718-drone-build-${DRONE_BUILD_NUMBER}'
 
   # Slack notification
   - name: slack-notification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@
 Use the latest tag from `VERSION.md` in examples; update these if the tag changes.
 - Build the image locally:
   ```sh
-  docker image build -t kernel528/postgres:18.4.0-260710 -f Dockerfile .
+  docker image build -t kernel528/postgres:18.4.0-260718 -f Dockerfile .
   ```
 - Run a container:
   ```sh
-  docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password -d kernel528/postgres:18.4.0-260710
+  docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password -d kernel528/postgres:18.4.0-260718
   ```
 - Manual smoke test (inside container):
   ```sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 
 # Based on: https://github.com/docker-library/postgres/blob/master/16/alpine3.21/Dockerfile
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Based on: [Postgres Official Docker - Alpine](https://github.com/docker-library/
 
 ## Build
 ```
-docker image build -t kernel528/postgres:18.4.0-260710 -f Dockerfile .
+docker image build -t kernel528/postgres:18.4.0-260718 -f Dockerfile .
 ```
 
 ## Run
 ```
-docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password --hostname=postgres-local -d kernel528/postgres:18.4.0-260710
+docker run -it -d -p 5432:5432 --name postgres-local -e POSTGRES_PASSWORD=password --hostname=postgres-local -d kernel528/postgres:18.4.0-260718
 ```
 
 ## Configuration
@@ -27,13 +27,13 @@ Common environment variables (aligned with the official Postgres image):
 - `POSTGRES_INITDB_ARGS` (extra `initdb` args)
 - `POSTGRES_INITDB_WALDIR` (optional WAL directory)
 - `POSTGRES_HOST_AUTH_METHOD` (e.g., `md5`, `scram-sha-256`, `trust`)
-- `PGDATA` (default: `/var/lib/postgresql/data`)
+- `PGDATA` (Postgres 18 default: `/var/lib/postgresql/18/docker`)
 
 Initialization scripts:
 - Mount or copy `.sh`, `.sql`, `.sql.gz`, `.sql.xz`, or `.sql.zst` files into `/docker-entrypoint-initdb.d` to run on first startup.
 
 Data persistence:
-- Mount a volume to `/var/lib/postgresql/data` to keep data across container restarts.
+- Mount a volume to `/var/lib/postgresql` to keep Postgres 18 data across container restarts.
 
 ### Example: data volume + init script
 ```
@@ -41,9 +41,9 @@ docker run -it -d \
   --name postgres-local \
   -p 5432:5432 \
   -e POSTGRES_PASSWORD=password \
-  -v postgres-data:/var/lib/postgresql/data \
+  -v postgres-data:/var/lib/postgresql \
   -v "$(pwd)/sample-postgres-db.sql:/docker-entrypoint-initdb.d/01-sample.sql:ro" \
-  kernel528/postgres:18.4.0-260710
+  kernel528/postgres:18.4.0-260718
 ```
 
 ## Tagging
@@ -68,7 +68,7 @@ exit         # container
 ### From another host or container
 If you have `psql` installed locally, or run it from a separate container:
 ```
-docker container run -it --rm --name psql-client --hostname psql-client kernel528/postgres:18.1.0-260128 psql -h 192.168.1.110 -U postgres
+docker container run -it --rm --name psql-client --hostname psql-client kernel528/postgres:18.4.0-260718 psql -h 192.168.1.110 -U postgres
 <password>
 select VERSION();
 \q

--- a/VERSION.md
+++ b/VERSION.md
@@ -29,3 +29,4 @@ Notes:
 - 16.11.0-260101: Updated base image to kernel528/alpine:3.23.2.
 - 18.1.0-260128: Updated to Postgres 18.1 and kernel528/alpine:3.23.2.
 - 18.4.0-260710: Updated to Postgres 18.4 and kernel528/alpine:3.24.1.
+- 18.4.0-260718: Rebuilt Postgres 18.4 on kernel528/alpine:3.24.1_1.


### PR DESCRIPTION
## Summary
- Rebuild PostgreSQL 18.4 on kernel528/alpine:3.24.1_1.
- Publish the PR image as 18.4.0-260718 rather than overwriting the current dated release.
- Align Drone and operator documentation with Postgres 18 volume layout at /var/lib/postgresql.

## Validation
- Base image manifest resolved: kernel528/alpine:3.24.1_1 (sha256:1741c5bedfaafd75d3783ad6c51a0a604c52d8ee7eb40e6d083ad9aa3a88c2d6).
- macOS linux/amd64 build reached PostgreSQL source compilation but failed in QEMU/GCC with a segmentation fault; native Drone build is required.

## Required Before Merge
- Native Drone PR build succeeds.
- Pull the published PR tag and run fresh-volume init, clean stop/restart, and psql query smoke checks.
- Confirm a current pg18 backup/restore test before any Swarm rollout.

No Swarm or persistent-volume changes are included.